### PR TITLE
Fix custom node namespace so generated extensions appear in the Editor (SWI-6715)

### DIFF
--- a/template/src/all/Nodes/ExampleProcessor/ExampleProcessorNode.hpp
+++ b/template/src/all/Nodes/ExampleProcessor/ExampleProcessorNode.hpp
@@ -8,7 +8,7 @@ namespace switchboard::extensions::exampledsp {
 class ExampleProcessorNode : public SingleBusAudioProcessorNode {
 public:
     static NodeTypeInfo getNodeTypeInfo() {
-        return NodeTypeInfo { SWITCHBOARD_NODE_NAMESPACE,
+        return NodeTypeInfo { "ExampleDSP",
                               "ExampleProcessor",
                               "ExampleProcessor",
                               "Example processor node.",

--- a/template/src/all/Nodes/ExampleSink/ExampleSinkNode.hpp
+++ b/template/src/all/Nodes/ExampleSink/ExampleSinkNode.hpp
@@ -8,7 +8,7 @@ namespace switchboard::extensions::exampledsp {
 class ExampleSinkNode : public SingleBusAudioSinkNode {
 public:
     static NodeTypeInfo getNodeTypeInfo() {
-        return NodeTypeInfo { SWITCHBOARD_NODE_NAMESPACE,
+        return NodeTypeInfo { "ExampleDSP",
                               "ExampleSink",
                               "ExampleSink",
                               "Example sink node.",

--- a/template/src/all/Nodes/ExampleSource/ExampleSourceNode.hpp
+++ b/template/src/all/Nodes/ExampleSource/ExampleSourceNode.hpp
@@ -8,7 +8,7 @@ namespace switchboard::extensions::exampledsp {
 class ExampleSourceNode : public SingleBusAudioSourceNode {
 public:
     static NodeTypeInfo getNodeTypeInfo() {
-        return NodeTypeInfo { SWITCHBOARD_NODE_NAMESPACE,
+        return NodeTypeInfo { "ExampleDSP",
                               "ExampleSource",
                               "ExampleSource",
                               "Example source node.",


### PR DESCRIPTION
## Problem

Extensions generated from this template do not show up as usable nodes in the Editor.

The example nodes declared their `NodeTypeInfo` namespace as `SWITCHBOARD_NODE_NAMESPACE`, which is **not** a per-extension macro — it's a hardcoded SDK constant:

```cpp
// SwitchboardSDK/include/switchboard_core/NodeTypeInfo.hpp
const std::string SWITCHBOARD_NODE_NAMESPACE = "Switchboard";
```

But the node factory's `getNodeTypePrefix()` returns the extension name (`"ExampleDSP"`), and the namespace declared on a node must match its factory's prefix. They didn't.

**Enumeration path** — `NodeRegistry::registerNode` registers each node under `namespace + "." + type`. With namespace `"Switchboard"`, the nodes register as `Switchboard.ExampleProcessor` etc., lumped in with the built-in SDK nodes and never grouped under the loaded extension.

**Instantiation path** — `SwitchboardObjectFactory::createNode` requires the requested namespace to equal a factory's `getNodeTypePrefix()`, so these nodes can only be created as `ExampleDSP.ExampleProcessor`. The advertised name (`Switchboard.*`) routes to the built-in factory, which has no such node, and returns `nullptr`.

The advertised name can never be instantiated and the instantiable name is never advertised, so generated extensions never usably appear in the Editor.

Shipping extensions (Waveshaper, Sox, …) match namespace to prefix and do not use `SWITCHBOARD_NODE_NAMESPACE`.

## Fix

Use the literal `"ExampleDSP"` string as the node namespace in the three example node headers, matching the factory prefix.

This is **generator-safe**: `scripts/rename.sh` does a literal `ExampleDSP` → project-name substitution across all files, so the node namespace and factory prefix rename in lockstep when a project is generated.

## Testing note

Verified by source trace against the SDK (`NodeRegistry`, `SwitchboardObjectFactory::createNode`, `NodeTypeInfo::getFQTypeName`) and by comparison with working extensions. A follow-up build + Editor smoke test of a generated extension is worth doing before close.

Fixes SWI-6715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)