### PR TITLE
Rename to BYON and reframe as an extension factory (SWI-6699)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Switchboard SDK – C++ Extension Template
+# BYON – Switchboard SDK Extension Factory
 
-[![Build](https://github.com/switchboard-sdk/cpp-extension-template/actions/workflows/build.yml/badge.svg)](https://github.com/switchboard-sdk/cpp-extension-template/actions/workflows/build.yml)
+[![Build](https://github.com/switchboard-sdk/BYON/actions/workflows/build.yml/badge.svg)](https://github.com/switchboard-sdk/BYON/actions/workflows/build.yml)
 
-This repository is a template for building custom C++ extensions for the Switchboard SDK. The actual project template lives in [`template/`](./template) — it's example code named `ExampleDSP` that demonstrates the extension architecture (source/processor/sink nodes, demos, CMake setup, etc.).
+BYON ("Bring Your Own Node") is an extension **factory** for the Switchboard SDK: it generates a new, independently-named C++ extension project that you then own and develop. It isn't a template you edit in place — you run the generator and it stamps out your project.
+
+What gets stamped out lives in [`template/`](./template) — example code named `ExampleDSP` that demonstrates the extension architecture (source/processor/sink nodes, demos, CMake setup, etc.).
+
+For the concepts behind custom nodes and extensions, see the [Bring Your Own Node](https://docs.switchboard.audio/guide/bring-your-own-node/overview/) guide.
 
 ## 🚀 Generating Your Project
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,8 +1,6 @@
-# Switchboard SDK – C++ Extension Template
+# ExampleDSP – a Switchboard SDK Extension
 
-[![Build](https://github.com/switchboard-sdk/cpp-extension-template/actions/workflows/build.yml/badge.svg)](https://github.com/switchboard-sdk/cpp-extension-template/actions/workflows/build.yml)
-
-Welcome to the **Switchboard SDK C++ Extension Template**! This repository provides a streamlined starting point for developers building custom C++ extensions for the Switchboard SDK. With this template, you can set up your development environment quickly and start implementing your own audio processing nodes.
+**ExampleDSP** is a custom C++ extension for the Switchboard SDK, generated from [BYON](https://github.com/switchboard-sdk/BYON). It ships with example source, processor, and sink nodes, runnable demos, and a ready-to-build CMake setup — replace the example nodes with your own audio processing.
 
 ---
 


### PR DESCRIPTION
Renames this repo to **BYON** and reframes it as what it actually is.

SWI-6663 (#14) split the repo into `scripts/` + `template/`, so `inv rename` now stamps out a new, independently named project rather than being a thing you edit in place. GitHub already agreed it wasn't a template (`is_template: false`) and the README already read as a generator manual. Only the name still said "template".

"BYON" is not a new coinage — docs.switchboard.audio already publishes a top-level [Bring Your Own Node](https://docs.switchboard.audio/guide/bring-your-own-node/overview/) guide. The repo, the docs and the concept now agree.

### Also fixed: generated projects inherited the factory's identity

`template/README.md` titled itself *"Switchboard SDK – C++ Extension Template"* and carried a CI badge pointing at **this repo's** build status. `rename.sh` only substitutes the `ExampleDSP` casings, so every generated project shipped claiming to be the extension template and advertising BYON's CI. Retitled to `ExampleDSP` (renames in lockstep with the rest) and dropped the badge.

### Deliberately unchanged

- **The `template/` directory name.** It's accurate — that directory *is* the payload. `.github/workflows/build.yml` hardcodes the literal path 14 times; renaming it buys nothing.
- **`is_template: false`.** Otherwise "Use this template" competes with `inv rename` and produces the wrong shape (a copy of the whole factory, `scripts/` included) — which is how `BYON-internal` was originally created before being collapsed by hand.

Old URLs redirect (verified: `301 -> /BYON`, and `git ls-remote` on the old URL still resolves), so the 2 stars, the out-of-org fork and the three docs links keep working. **Do not recreate `cpp-extension-template` in the org** — that kills the redirect.

Linear: SWI-6699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
